### PR TITLE
Upgrade main Python version to 3.10 for CI/CD.

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -11,7 +11,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.9'
+  MAIN_PYTHON_VERSION: '3.10'
   PACKAGE_NAME: 'ansys-seascape'
   PACKAGE_NAMESPACE: 'ansys.seascape'
   DOCUMENTATION_CNAME: 'seascape.docs.pyansys.com'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       additional_dependencies: [black==22.12.0]
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
   - id: isort
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
 - repo: https://github.com/psf/black
-  rev: 22.12.0  # IF VERSION CHANGES --> MODIFY "blacken-docs" MANUALLY AS WELL!!
+  rev: 23.1.0  # IF VERSION CHANGES --> MODIFY "blacken-docs" MANUALLY AS WELL!!
   hooks:
   - id: black
 
@@ -9,7 +9,7 @@ repos:
   rev: v1.12.1
   hooks:
   -   id: blacken-docs
-      additional_dependencies: [black==22.12.0]
+      additional_dependencies: [black==23.1.0]
 
 - repo: https://github.com/pycqa/isort
   rev: 5.12.0

--- a/src/ansys/seascape/utils.py
+++ b/src/ansys/seascape/utils.py
@@ -95,6 +95,6 @@ def write_to_file(file_name, *args, **kwargs):
     ff = open(file_name, "w")
     for x in args:
         ff.write(f"{x}\n")
-    for (x, y) in kwargs.items():
+    for x, y in kwargs.items():
         ff.write(f"{x} = {y}\n")
     ff.close()


### PR DESCRIPTION
This should fix the issue related to `isort`.
Otherwise we can downgrade `isort`to 5.11.5.
As soon as this PR is merged, it should allow the workflows of the PR #59 to pass.